### PR TITLE
Check context tokens and spanish support

### DIFF
--- a/context_info.md
+++ b/context_info.md
@@ -1,0 +1,47 @@
+# Información sobre el Modelo / Model Information
+
+## Tokens de Contexto / Context Tokens
+Como Claude 3 Opus, tengo una ventana de contexto de **200,000 tokens**. Esto significa que puedo procesar y mantener en memoria aproximadamente:
+- ~150,000 palabras de texto
+- ~680,000 caracteres
+
+## Soporte de Español / Spanish Language Support
+Sí, tengo soporte completo para español. Puedo:
+- ✅ Entender español con fluidez
+- ✅ Responder en español
+- ✅ Traducir entre español y otros idiomas
+- ✅ Programar con comentarios y documentación en español
+- ✅ Ayudarte con tareas de programación explicadas en español
+
+## Ejemplo de Código con Comentarios en Español
+
+```python
+# Función para calcular el factorial de un número
+def factorial(n):
+    """
+    Calcula el factorial de un número entero positivo.
+    
+    Args:
+        n (int): El número del cual calcular el factorial
+        
+    Returns:
+        int: El factorial de n
+    """
+    if n <= 1:
+        return 1
+    else:
+        return n * factorial(n - 1)
+
+# Ejemplo de uso
+numero = 5
+resultado = factorial(numero)
+print(f"El factorial de {numero} es {resultado}")
+```
+
+## Capacidades Multilingües
+Puedo trabajar sin problemas mezclando español e inglés, lo cual es común en programación donde:
+- Los nombres de funciones y variables suelen estar en inglés
+- Los comentarios y documentación pueden estar en español
+- La comunicación con el usuario puede ser en cualquier idioma
+
+¿Hay algo específico en lo que te gustaría que te ayude en español?


### PR DESCRIPTION
Add `context_info.md` to provide information about the AI's context token limit and its Spanish language support.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d404994-d313-47c6-a309-f51f5fdebdf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d404994-d313-47c6-a309-f51f5fdebdf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

