### PR TITLE
Fix python script for flag retrieval

### DIFF
--- a/recon/fixme1.py
+++ b/recon/fixme1.py
@@ -1,0 +1,21 @@
+
+import random
+
+
+
+def str_xor(secret, key):
+    #extend key to secret length
+    new_key = key
+    i = 0
+    while len(new_key) < len(secret):
+        new_key = new_key + key[i]
+        i = (i + 1) % len(key)        
+    return "".join([chr(ord(secret_c) ^ ord(new_key_c)) for (secret_c,new_key_c) in zip(secret,new_key)])
+
+
+flag_enc = chr(0x15) + chr(0x07) + chr(0x08) + chr(0x06) + chr(0x27) + chr(0x21) + chr(0x23) + chr(0x15) + chr(0x5a) + chr(0x07) + chr(0x00) + chr(0x46) + chr(0x0b) + chr(0x1a) + chr(0x5a) + chr(0x1d) + chr(0x1d) + chr(0x2a) + chr(0x06) + chr(0x1c) + chr(0x5a) + chr(0x5c) + chr(0x55) + chr(0x40) + chr(0x3a) + chr(0x58) + chr(0x0a) + chr(0x5d) + chr(0x53) + chr(0x43) + chr(0x06) + chr(0x56) + chr(0x0d) + chr(0x14)
+
+  
+flag = str_xor(flag_enc, 'enkidu')
+print('That is correct! Here\'s your flag: ' + flag)
+

--- a/recon/fixme2.py
+++ b/recon/fixme2.py
@@ -1,0 +1,27 @@
+
+import random
+
+
+
+def str_xor(secret, key):
+    #extend key to secret length
+    new_key = key
+    i = 0
+    while len(new_key) < len(secret):
+        new_key = new_key + key[i]
+        i = (i + 1) % len(key)        
+    return "".join([chr(ord(secret_c) ^ ord(new_key_c)) for (secret_c,new_key_c) in zip(secret,new_key)])
+
+
+flag_enc = chr(0x15) + chr(0x07) + chr(0x08) + chr(0x06) + chr(0x27) + chr(0x21) + chr(0x23) + chr(0x15) + chr(0x58) + chr(0x18) + chr(0x11) + chr(0x41) + chr(0x09) + chr(0x5f) + chr(0x1f) + chr(0x10) + chr(0x3b) + chr(0x1b) + chr(0x55) + chr(0x1a) + chr(0x34) + chr(0x5d) + chr(0x51) + chr(0x40) + chr(0x54) + chr(0x09) + chr(0x05) + chr(0x04) + chr(0x57) + chr(0x1b) + chr(0x11) + chr(0x31) + chr(0x0d) + chr(0x5f) + chr(0x05) + chr(0x40) + chr(0x04) + chr(0x0b) + chr(0x0d) + chr(0x0a) + chr(0x19)
+
+  
+flag = str_xor(flag_enc, 'enkidu')
+
+# Check that flag is not empty
+if flag == "":
+  print('String XOR encountered a problem, quitting.')
+else:
+  print('That is correct! Here\'s your flag: ' + flag)
+
+

--- a/recon/flag.txt
+++ b/recon/flag.txt
@@ -1,0 +1,1 @@
+picoCTF{1nd3nt1ty_cr1515_6a476c8f}

--- a/recon/flag.txt
+++ b/recon/flag.txt
@@ -1,1 +1,2 @@
 picoCTF{1nd3nt1ty_cr1515_6a476c8f}
+picoCTF{3qu4l1ty_n0t_4551gnm3nt_f6a5aefc}


### PR DESCRIPTION
Add the corrected `fixme1.py` script and the obtained flag to resolve the picoCTF `fixme1` challenge.

The `fixme1.py` script required a syntax correction (indentation fix on line 20) to execute successfully and reveal the embedded flag.

---
<a href="https://cursor.com/background-agent?bcId=bc-e818f57d-91a1-4ea3-b2ce-85a786c02d03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e818f57d-91a1-4ea3-b2ce-85a786c02d03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

